### PR TITLE
Update rwdgrid.css

### DIFF
--- a/css/rwdgrid.css
+++ b/css/rwdgrid.css
@@ -44,10 +44,7 @@ Github URI: https://github.com/gsvineeth/rwdgrid/
     clear:both;
     float:inherit;
 }
-.container {
-    margin:0%;
-    width: 100%;
-}
+
 .container:after, .container:before {
     display: table;
     clear:both;


### PR DESCRIPTION
You need to remove
```
.container {
    margin:0%;
    width: 100%;
}
```
This style rule will make the browser misbehave by adding extra space to the left.
 I solved my problem by setting  my own container, for example:
```
 .container {
    margin: 0 auto;
    width: 100%;
    max-width: 940px;
}
```

